### PR TITLE
Do not install vulkan headers, but add imx_icd so it loads libvulkan_VSI so it doesn't conflict with libvulkan-dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+imx-gpu-viv (6.4.11.p2.4-4) bookworm; urgency=medium
+
+  * Team upload.
+  * Do not install vulkan headers, but add imx_icd so it loads libvulkan_VSI
+      - d/extra_files/imx_icd.json: add file from meta-freescale to tell
+        vulkan-loader to use libvulkan_VSI provided by imx-gpu-viv-wayland;
+      - d/imx-gpu-viv-wayland.install: install imx_icd.json;
+      - d/rules: sed imx_icd.json with correct values and drop vulkan headers.
+
+ -- Carlos Henrique Lima Melara <carlos.melara@toradex.com>  Thu, 07 Nov 2024 18:10:11 -0300
+
 imx-gpu-viv (6.4.11.p2.4-3) bookworm; urgency=medium
 
   * Team upload.

--- a/debian/extra_files/imx_icd.json
+++ b/debian/extra_files/imx_icd.json
@@ -1,0 +1,7 @@
+{
+    "file_format_version": "1.0.0",
+    "ICD": {
+        "library_path": "%libdir%/libvulkan_VSI.so.1",
+        "api_version": "%api_version%"
+    }
+}

--- a/debian/imx-gpu-viv-wayland-dev.install
+++ b/debian/imx-gpu-viv-wayland-dev.install
@@ -1,2 +1,2 @@
-gpu-core/usr/include/* /usr/include/
+gpu-core/usr/include/*     /usr/include/
 gpu-core/usr/lib/pkgconfig /usr/lib/aarch64-linux-gnu/

--- a/debian/imx-gpu-viv-wayland.install
+++ b/debian/imx-gpu-viv-wayland.install
@@ -1,2 +1,3 @@
-gpu-core/etc/Vivante.icd /etc/OpenCL/vendors/
-gpu-core/usr/lib/lib*.so* /usr/lib/aarch64-linux-gnu/
+debian/extra_files/imx_icd.json /etc/vulkan/icd.d/
+gpu-core/etc/Vivante.icd        /etc/OpenCL/vendors/
+gpu-core/usr/lib/lib*.so*       /usr/lib/aarch64-linux-gnu/

--- a/debian/rules
+++ b/debian/rules
@@ -4,12 +4,13 @@
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
+DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 DEB_BUILD_OPTIONS=noautodbgsym
+
 FILENAME="imx-gpu-viv-6.4.11.p2.4d-aarch64"
 URL="https://www.nxp.com/lgfiles/sdk/lsdk2406/$(FILENAME).bin"
 
-LIBVULKAN_VERSION=1.2.1
-LIBVULKAN_VERSION_MAJOR=1
+LIBVULKAN_API_VERSION=1.3.239
 
 %:
 	dh $@
@@ -22,9 +23,15 @@ override_dh_auto_configure:
 	# Also remove usr/include/KHR/khrplatform.h and
 	# usr/lib/pkgconfig/gl.pc. We are using Debian's
 	# default ones which comes from libgl-dev package.
-	find . -iname khrplatform.h -exec rm -vf '{}' \;
+	rm -rvf `find . -iname khr`
 	find . -iname gl.pc -exec rm -vf '{}' \;
+	# And vulkan headers too as is done in meta-freescale
+	rm -rvf `find . -iname vulkan`
 
+execute_before_dh_install:
+	sed -e "s|%libdir%|/usr/lib/$(DEB_HOST_GNU_TYPE)|" \
+	    -e "s|%api_version%|$(LIBVULKAN_API_VERSION)|" \
+	    -i `find . -iname imx_icd.json`
 
 override_dh_strip_nondeterminism:
 


### PR DESCRIPTION
Same as done in https://github.com/Freescale/meta-freescale/commit/6b4da0b0a91637fe54f89d2389e43625ba1d753c